### PR TITLE
18-Add health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,5 +202,7 @@ EXPOSE 23424/tcp
 # HTTPS/1.1 /cds /mediabrowser
 EXPOSE 23524/tcp
 
+HEALTHCHECK --start-period=5m CMD wget --quiet --tries=1 -O /dev/null --server-response --timeout=5 http://127.0.0.1:23423/console/ || exit 1
+
 #-Dserviio.defaultTranscodeFolder=/opt/serviio/transcode 
 CMD tail -f /opt/serviio/log/serviio.log & /opt/serviio/bin/serviio.sh


### PR DESCRIPTION
Adds basic health check for containerd
https://github.com/rb-dock8s/serviio/issues/18


As a side note (not relevant to this PR), project builds successfully using `FFMPEG_VERSION=4.3.1` in place of `FFMPEG_VERSION=4.2`.