### PR TITLE
Update Serviio version to 2.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER "[riftbit] ErgoZ <ergozru@gmail.com>"
 
 ARG BUILD_DATE
 ARG VCS_REF
-ARG VERSION=2.2
+ARG VERSION=2.2.1
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
 	org.label-schema.name="DLNA Serviio Container" \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Link on github: [riftbit/docker-serviio](https://github.com/riftbit/docker-servi
 
 ### Build Args
 
- - `VERSION` = 2.2 - serviio version
+ - `VERSION` = 2.2.1 - serviio version
  - `FFMPEG_VERSION` = 4.2
 
 
@@ -32,6 +32,7 @@ Link on github: [riftbit/docker-serviio](https://github.com/riftbit/docker-servi
 
 
 ### Container Changelog (dd.mm.yy)
+ - **16.12.2021** - Update Serviio version to 2.2.1
  - **01.10.2021** - Update Serviio version to 2.2
  - **19.03.2021** - Update FFMPEG to 4.3.2, add healthcheck (PR #19), cleanup volumes (mount only if you need it)
  - **07.12.2020** - Update alpine to 3.12, fix dcraw.c build (add jasper build from source), removed config volume


### PR DESCRIPTION
Release Notes from Serviio 2.2.1:

- updated Log4j to 2.15.0